### PR TITLE
Feat/update to cache manager v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm package](https://img.shields.io/npm/v/cache-manager-fs-hash.svg)](https://www.npmjs.com/package/cache-manager-fs-hash)
 [![node](https://img.shields.io/node/v/cache-manager-fs-hash.svg)](https://nodejs.org)
 
-A Filesystem store for the [node-cache-manager](https://github.com/BryanDonovan/node-cache-manager) module
+A Filesystem store for the [node-cache-manager](https://github.com/jaredwray/cache-manager) module
 
 ## Installation
 
@@ -30,7 +30,7 @@ const diskCache = cacheManager.caching({
     store: fsStore,
     options: {
         path: 'diskcache', //path for cached files
-        ttl: 60 * 60,      //time to life in seconds
+        ttl: 60 * 1000,    //time to life in miliseconds (on cache-manager v5)
         subdirs: true,     //create subdirectories to reduce the
                            //files in a single dir (default: false)
         zip: true,         //zip files to save diskspace (default: false)
@@ -42,10 +42,14 @@ const diskCache = cacheManager.caching({
 
     await diskCache.set('key', 'value');
     console.log(await diskCache.get('key')); //"value"
-    console.log(await diskCache.ttl('key')); //3600 seconds
+    console.log(await diskCache.ttl('key')); // 5999 miliseconds
     await diskCache.del('key');
     console.log(await diskCache.get('key')); //undefined
 
+    await diskCache.set('key', 'value', 1000); // With custom TTL
+    console.log(await diskCache.get('key')); // "value"
+    console.log(await diskCache.ttl('key')); // 999 miliseconds
+    await diskCache.del('key');
 
     console.log(await getUserCached(5)); //{id: 5, name: '...'}
     console.log(await getUserCached(5)); //{id: 5, name: '...'}

--- a/examples/from-readme.js
+++ b/examples/from-readme.js
@@ -5,7 +5,7 @@ const diskCache = cacheManager.caching({
     store: fsStore,
     options: {
         path: 'diskcache', // path for cached files
-        ttl: 60 * 60, // time to life in seconds
+        ttl: 60 * 1000, // time to life in miliseconds
         subdirs: true, //create subdirectories to reduce the files in a single dir (default: false)
         zip: true, //zip files to save diskspace (default: false)
     }
@@ -16,11 +16,15 @@ const diskCache = cacheManager.caching({
 
     await diskCache.set('key', 'value');
     console.log(await diskCache.get('key')); // "value"
-    console.log(await diskCache.ttl('key')); // 3599.99 seconds
+    console.log(await diskCache.ttl('key')); // 5999 miliseconds
     await diskCache.del('key');
     console.log(await diskCache.get('key')); // undefined
 
-
+    await diskCache.set('key', 'value', 1000); // With custom TTL
+    console.log(await diskCache.get('key')); // "value"
+    console.log(await diskCache.ttl('key')); // 999 miliseconds
+    await diskCache.del('key');
+    
     console.log(await getUserCached(5)); // {id: 5, name: '...'}
     console.log(await getUserCached(5)); // {id: 5, name: '...'}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,7 +162,8 @@ describe('DiskStore', function () {
         });
 
         it('should not load expired data (set options)', async function () {
-            await cache.set('key', 'value', {ttl: 0});
+            const ttl = 0
+            await cache.set('key', 'value', ttl);
             const loadedValue = await cache.get('key');
             assert.strictEqual(undefined, loadedValue);
         });
@@ -302,10 +303,12 @@ describe('DiskStore', function () {
     describe('set() and ttl()', function () {
 
         it('should get the right ttl', async function () {
-            const cache = store.create({path: cacheDirectory, ttl: 10});
+            const setttl = 10,
+                fsReadDelayTime = setttl - 2; // The time is expressed in miliseconds, the read operation should be taken as diff
+            const cache = store.create({path: cacheDirectory, ttl: setttl});
             await cache.set('key', 'value');
             const ttl = Math.round(await cache.ttl('key'));
-            assert.strictEqual(10, ttl);
+            assert( ttl >= fsReadDelayTime && ttl <= setttl);
         });
 
     });


### PR DESCRIPTION
Update API to match changes on v5 of cache-manager on the `set` function

- Change the TTL unit from seconds to miliseconds
- Change the third parameter of `set` to number [ref](https://github.com/jaredwray/cache-manager/blob/main/packages/cache-manager/src/caching.ts#L22)
- Cheat on test to match the expected value (assume a little delay while reading from fs)

Also note that the [old repo](https://github.com/jaredwray/cache-manager/releases/tag/2024-04-05) will be shutdown